### PR TITLE
Add bat_name: BAT1 to the example config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All options are detailed [here](https://github.com/doums/bato/blob/master/bato.y
 Example:
 ```yaml
 tick_rate: 1
+bat_name: BAT1
 critical_level: 5
 low_level: 30
 critical:


### PR DESCRIPTION
Proposing this change because I got stuck for a while not knowing what wasn't working, turns out you need to specify this anyway.